### PR TITLE
terminal_snake

### DIFF
--- a/terminal_snake_CMake/menu/menu.c
+++ b/terminal_snake_CMake/menu/menu.c
@@ -25,6 +25,9 @@
 /****************************************************************************/
 /*                    Local macros and defines                              */
 /****************************************************************************/
+#ifdef WINDOWS_ENV
+#define MENU_ENTER_KEY_ASCII                                              13u
+#endif
 
 /****************************************************************************/
 /*                    Local data types                                      */
@@ -188,26 +191,24 @@ void menu_mode(void)
                     currentOption--;
                     menu_updateDisplayTemplate(currentOption);
                     break;
-                case 'a':
-                    break;
                 case 's':
                     if (currentOption == eExit)
                         continue;
                     currentOption++;
                     menu_updateDisplayTemplate(currentOption);
                     break;
-                case 'd':
-                    break;
                 case 'q':
                     goto EXIT;
-                    break;
+
+#if defined WINDOWS_ENV
+                case MENU_ENTER_KEY_ASCII:
+#elif defined LINUX_ENV
                 case '\n':
-                case 13:
+#endif /* defined WINDOWS_ENV */
                     switch(currentOption)
                     {
                         case eExit:
                             goto EXIT;
-                            break;
                         default:
                             /* TODO: replace the code example */
                             display_clear();

--- a/terminal_snake_CMake/menu/menu.c
+++ b/terminal_snake_CMake/menu/menu.c
@@ -202,6 +202,7 @@ void menu_mode(void)
                     goto EXIT;
                     break;
                 case '\n':
+                case 13:
                     switch(currentOption)
                     {
                         case eExit:


### PR DESCRIPTION
Fix enter key in menu mode for windows
Done by adding case 13, which is enter in ascii for windows